### PR TITLE
Hide the add link button on groups

### DIFF
--- a/css/override.css
+++ b/css/override.css
@@ -1,3 +1,7 @@
 a.map-header-button {
   display: none;
 }
+
+#bpfb_addLinks {
+  display: none;
+}


### PR DESCRIPTION
it’s broken and we don’t want to fix it. They can just paste links into the text.