### PR TITLE
Changing font-display to 'swap'.

### DIFF
--- a/fonts/font-faces.css
+++ b/fonts/font-faces.css
@@ -8,7 +8,7 @@
          url("./Lato-Regular.ttf") format('truetype');
     font-weight: 400;
     font-style: normal;
-    font-display: auto;
+    font-display: swap;
 }
 
 /* Lato italic */
@@ -22,7 +22,7 @@
          url('./Lato-Italic.ttf') format('truetype');
     font-weight: 400;
     font-style: italic;
-    font-display: auto;
+    font-display: swap;
 }
 
 /* Lato bold */
@@ -36,7 +36,7 @@
          url('./Lato-Bold.ttf') format('truetype');
     font-weight: 700;
     font-style: normal;
-    font-display: auto;
+    font-display: swap;
 }
 
 /* Lato black */
@@ -50,7 +50,7 @@
          url('./Lato-Black.ttf') format('truetype');
     font-weight: 900;
     font-style: normal;
-    font-display: auto;
+    font-display: swap;
 }
 
 /* Lato light */
@@ -64,7 +64,7 @@
          url('./Lato-Light.ttf') format('truetype');
     font-weight: 300;
     font-style: normal;
-    font-display: auto;
+    font-display: swap;
 }
 
 /* Lato thin */
@@ -78,7 +78,7 @@
          url('./Lato-Thin.ttf') format('truetype');
     font-weight: 100;
     font-style: normal;
-    font-display: auto;
+    font-display: swap;
 }
 
 /* Lato bold italic */
@@ -92,7 +92,7 @@
          url('./Lato-BoldItalic.ttf') format('truetype');
     font-weight: 700;
     font-style: italic;
-    font-display: auto;
+    font-display: swap;
 }
 
 /* Lato black italic */
@@ -106,7 +106,7 @@
          url('./Lato-BlackItalic.ttf') format('truetype');
     font-weight: 900;
     font-style: italic;
-    font-display: auto;
+    font-display: swap;
 }
 
 /* Lato light italic */
@@ -120,7 +120,7 @@
          url('./Lato-LightItalic.ttf') format('truetype');
     font-weight: 300;
     font-style: italic;
-    font-display: auto;
+    font-display: swap;
 }
 
 /* Lato thin italic*/
@@ -134,5 +134,5 @@
          url('./Lato-ThinItalic.ttf') format('truetype');
     font-weight: 100;
     font-style: italic;
-    font-display: auto;
+    font-display: swap;
 }


### PR DESCRIPTION
Changing font-display to 'swap'.

The font-display API specifies how a font is displayed. swap tells the browser that text using the font should be displayed immediately using a system font.